### PR TITLE
Allow constructors to be instantiated without parens with params 

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -94,9 +94,6 @@
     "no_unnecessary_fat_arrows": {
         "level": "warn"
     },
-    "non_empty_constructor_needs_parens": {
-        "level": "error"
-    },
     "space_operators": {
         "level": "warn"
     }


### PR DESCRIPTION
eg. `new ClassName param`
