### PR TITLE
Staging fixes

### DIFF
--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -170,6 +170,7 @@ gulp.task 'scripts:prod', ['lint:scripts'], ->
     extensions: ['.coffee']
   .transform {global: true}, 'uglifyify'
   .bundle()
+  .on 'error', errorHandler
   .pipe source outFiles.scripts
   .pipe gulp.dest paths.dist + '/js/'
 

--- a/src/coffee/root.coffee
+++ b/src/coffee/root.coffee
@@ -31,7 +31,7 @@ if kik?.picker?.reply
       kik.picker.reply()
     .catch (err) ->
       log.trace err
-  return # stop executing code
+  throw new Error 'Stop code execution'
 
 reportError = ->
 
@@ -105,6 +105,8 @@ if shouldRouteToGamePage
     kik?.picker?(marketplaceBaseUrl, {}, -> null)
 
   z.route "/game/#{gameKey}"
+else
+  PushToken.all('pushTokens').createForMarketplace()
 
 log.info 'App Ready'
 


### PR DESCRIPTION
- uglify doesn't allow return outside of a function. added error logging
  to gulpfile and replaced the return with a throw (to stop code execution)
- made it so we store marketplace token on clay.io marketplace load
