### PR TITLE
ga: send pageviews for games

### DIFF
--- a/src/coffee/pages/play_game.coffee
+++ b/src/coffee/pages/play_game.coffee
@@ -2,12 +2,19 @@ z = require 'zorium'
 
 GamePlayer = require '../components/game_player'
 ModalViewer = require '../components/modal_viewer'
+UrlService = require '../services/url'
 
 module.exports = class PlayGamePage
   constructor: (params) ->
     gameKey = params 'key'
     @GamePlayer = new GamePlayer gameKey: gameKey
     @ModalViewer = new ModalViewer()
+
+    # FIXME: this should be implemented at zorium-level
+    # don't send for direct hits to game since GA already does
+    # WARNING: this doesn't set the proper title
+    if UrlService.isRootPath()
+      ga? 'send', 'pageview', "/#{gameKey}"
 
   render: =>
     z 'div',


### PR DESCRIPTION
This is a hack - the ideal solution is baked into Zorium.
 This hack should only log when users are routed to a game through mithril
