### PR TITLE
accessToken: wiping out all old access tokens by renaming to accessToken...

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -46,7 +46,7 @@ clayUserSessionMiddleware = ->
 
     loginUrl = config.CLAY_API_URL + '/users/login/anon'
     meUrl = config.CLAY_API_URL + '/users/me'
-    accessToken = req.cookies.accessToken
+    accessToken = req.cookies[config.ACCESS_TOKEN_COOKIE_KEY]
 
     # Don't inject user because the page is sent over http
     if accessToken

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -6,6 +6,7 @@ module.exports =
   WEBPACK_DEV_HOSTNAME: process.env.WEBPACK_DEV_HOSTNAME or 'localhost'
   MOCK: process.env.MOCK or false
   ENV: process.env.NODE_ENV or 'production'
+  ACCESS_TOKEN_COOKIE_KEY: 'accessToken2'
   ENVS:
     DEV: 'development'
     PROD: 'production'

--- a/src/models/user.coffee
+++ b/src/models/user.coffee
@@ -17,7 +17,6 @@ setHostCookie = (key, value) ->
   secondLevelDomain = window.location.hostname.split('.').slice(-2).join('.')
   # The '.' prefix allows subdomains access
   domain = '.' + secondLevelDomain
-  document.cookie = "#{key}=#{value}"
   document.cookie = "#{key}=#{value};path=/;domain=#{domain}"
 
 class User
@@ -29,11 +28,11 @@ class User
       else request PATH + '/login/anon',
         method: 'POST'
         qs:
-          accessToken: getCookieValue 'accessToken'
+          accessToken: getCookieValue config.ACCESS_TOKEN_COOKIE_KEY
 
       # Save accessToken in cookie
       me.then (user) ->
-        setHostCookie 'accessToken', user.accessToken
+        setHostCookie config.ACCESS_TOKEN_COOKIE_KEY, user.accessToken
       .catch log.trace
 
     return me
@@ -43,7 +42,7 @@ class User
 
     # Save accessToken in cookie
     me.then (user) ->
-      setHostCookie 'accessToken', user.accessToken
+      setHostCookie config.ACCESS_TOKEN_COOKIE_KEY, user.accessToken
     .catch log.trace
 
     experiments = me.then (user) ->

--- a/src/root.coffee
+++ b/src/root.coffee
@@ -121,7 +121,7 @@ new Promise (resolve) ->
   # ENGAGED GAMEPLAYS #
   #####################
 
-  hasVisitedBefore = _.contains document.cookie, 'accessToken'
+  hasVisitedBefore = _.contains document.cookie, config.ACCESS_TOKEN_COOKIE_KEY
 
   if isFromShare and not hasVisitedBefore
     # The anon-token is unique for each 'app', so always use the marketplace one


### PR DESCRIPTION
...2 (also moved to config)

Reason is we were writing the accessToken cookie individually on each
page, meaning on some pages you would be one user, and another on other pages