### PR TITLE
zorium: bump to 0.6.8 to fix too-many-signups bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "portal-gun": "0.1.0",
     "promiz": "1.0.0",
     "request-promise": "0.3.2",
-    "zorium": "^0.6.7"
+    "zorium": "^0.6.8"
   }
 }


### PR DESCRIPTION
on iOS zorium was routing before setMe, thus calling getMe first which led to
to many user:loginAnon:creates