### PR TITLE
friends: bug-fixes

### DIFF
--- a/src/components/dev_login/index.coffee
+++ b/src/components/dev_login/index.coffee
@@ -46,7 +46,7 @@ module.exports = class DevLogin
   login: =>
     User.loginBasic {email: @o_email(), password: @o_password()}
     .then (me) ->
-      User.setMe me
+      User.setMe Promise.resolve me
     .then ({id}) ->
       Developer.find {ownerId: id }
     .then (developers) ->

--- a/src/components/forgot_password/index.coffee
+++ b/src/components/forgot_password/index.coffee
@@ -33,8 +33,7 @@ module.exports = class ForgotPassword
       User.recoverLogin {phone}
     .catch (err) =>
       # TODO: (Austin) better error handling
-      error = JSON.parse err._body
-      @state.o_phoneError.set error.detail
+      @state.o_phoneError.set err.detail
       throw err
     .then ->
       z.router.go '/reset-password/' + encodeURIComponent phone

--- a/src/components/friend_request_card/index.coffee
+++ b/src/components/friend_request_card/index.coffee
@@ -1,6 +1,7 @@
 z = require 'zorium'
 Button = require 'zorium-paper/button'
 
+User = require '../../models/user'
 Icon = require '../icon'
 styleConfig = require '../../stylus/vars.json'
 
@@ -30,7 +31,7 @@ module.exports = class FriendRequestCard
           z 'img.profile-pic',
             src: User.getAvatarUrl friends[0]
           z 'div.friend-info',
-            z 'div.title', friends[0].name
+            z 'div.title', friends[0].name or User.DEFAULT_NAME
             z 'div.description', 'is now your friend!'
       else
         z 'div.many-friends',

--- a/src/components/friends/index.coffee
+++ b/src/components/friends/index.coffee
@@ -41,7 +41,7 @@ module.exports = class Friends
                 z 'img.friend-avatar',
                   src: User.getAvatarUrl friend
                 z 'div.friend-info',
-                  z 'div.name', friend.name
+                  z 'div.name', friend.name or User.DEFAULT_NAME
                   if mostRecentGame
                     z 'div.game', mostRecentGame.name
                 if mostRecentGame

--- a/src/components/icon/index.coffee
+++ b/src/components/icon/index.coffee
@@ -9,13 +9,14 @@ module.exports = class Icon
     styles.use()
 
   render: ({icon, size, isAlignedLeft, isAlignedRight, isTouchTarget,
-            color, onclick}) ->
+            color, onclick, ontouchstart}) ->
     size ?= '24px'
     isTouchTarget ?= true
 
     z 'div.z-icon', {
       className: z.classKebab {isAlignedLeft, isAlignedRight, isTouchTarget}
       onclick: onclick
+      ontouchstart: ontouchstart
     },
       z 'svg', {
         namespace: 'http://www.w3.org/2000/svg'

--- a/src/components/icon/index.styl
+++ b/src/components/icon/index.styl
@@ -5,10 +5,12 @@ json('../../stylus/vars.json')
 .z-icon
   text-align: center
   display: flex
+  -webkit-tap-highlight-color: $transparent
 
   > svg
     vertical-align: middle
     margin: auto
+    -webkit-tap-highlight-color: $transparent
 
   &.is-touch-target
     min-width: 48px

--- a/src/components/invite/index.coffee
+++ b/src/components/invite/index.coffee
@@ -3,6 +3,7 @@ z = require 'zorium'
 Icon = require '../icon'
 PrimaryButton = require '../primary_button'
 InviteService = require '../../services/invite'
+EnvironmentService = require '../../services/environment'
 User = require '../../models/user'
 styleConfig = require '../../stylus/vars.json'
 
@@ -45,6 +46,8 @@ module.exports = class Invite
     z '.z-invite',
       z 'div.invite-options',
         _.map shareMethods, ({className, title, $icon, iconName, inviteFn}) ->
+          if className is 'kik' and not EnvironmentService.isKikEnabled()
+            return
           z 'a[href=#].invite', {
             onclick: ->
               inviteFn {userId: me.id}

--- a/src/components/invite_landing/index.coffee
+++ b/src/components/invite_landing/index.coffee
@@ -40,7 +40,7 @@ module.exports = class InviteLanding
           height: "#{CONTENT_HEIGHT}px"
       },
         z $befriendButton,
-          text: "Become friends with #{name or 'everyone'}"
+          text: "Become friends with #{fromUser?.name or 'everyone'}"
           isFullWidth: true
           onclick: ->
             User.isLoggedIn().then (isLoggedIn) ->

--- a/src/components/join/index.coffee
+++ b/src/components/join/index.coffee
@@ -47,16 +47,19 @@ module.exports = class Join
     password = @state.o_password()
     phone = @state.o_phone()
 
+    unless name
+      @state.o_nameError.set 'Please enter a name'
+      return
+
     PhoneService.normalizePhoneNumber phone
     .then (phone) ->
       User.loginPhone {phone, password}
     .catch (err) =>
       # TODO: (Austin) better error handling
-      error = JSON.parse err._body
-      @state.o_phoneError.set error.detail
+      @state.o_phoneError.set err.detail
       throw err
     .then (me) ->
-      User.setMe me
+      User.setMe Promise.resolve me
     .then (me) ->
       User.updateMe({name: name}).catch log.trace
 

--- a/src/components/login/index.coffee
+++ b/src/components/login/index.coffee
@@ -44,11 +44,10 @@ module.exports = class Login
       User.loginPhone {phone, password}
     .catch (err) =>
       # TODO: (Austin) better error handling
-      error = JSON.parse err._body
-      @state.o_phoneError.set error.detail
+      @state.o_phoneError.set err.detail
       throw err
     .then (me) ->
-      User.setMe me
+      User.setMe Promise.resolve me
       z.router.go '/'
 
   render: =>

--- a/src/components/menu_button/index.coffee
+++ b/src/components/menu_button/index.coffee
@@ -17,5 +17,9 @@ module.exports = class MenuButton
         isAlignedLeft: isAlignedLeft
         icon: 'menu'
         color: styleConfig.$white
-        onclick: ->
+        ontouchstart: (e) ->
+          e?.preventDefault()
+          NavDrawerModel.open()
+        onclick: (e) ->
+          e?.preventDefault()
           NavDrawerModel.open()

--- a/src/components/nav_drawer/index.styl
+++ b/src/components/nav_drawer/index.styl
@@ -31,6 +31,7 @@ $zIndexNavDrawerHeader = 100
     transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)
     width: 100%
     height: 100%
+    -webkit-tap-highlight-color: $transparent
 
   > .drawer
     // width and transform translate set in js

--- a/src/components/reset_password/index.coffee
+++ b/src/components/reset_password/index.coffee
@@ -41,8 +41,8 @@ module.exports = class ResetPassword
     .then (phone) ->
       User.recoverLogin {phone}
     .catch (err) =>
-      error = JSON.parse err._body
-      @state.o_newPasswordError.set error.detail
+      # TODO: (Austin) better error handling
+      @state.o_newPasswordError.set err.detail
       throw err
     .then =>
       # hide resend button so they can't spam-click it
@@ -56,8 +56,8 @@ module.exports = class ResetPassword
     .then (phone) ->
       User.loginPhone {phone, recoveryToken, password: newPassword}
     .catch (err) =>
-      error = JSON.parse err._body
-      @state.o_newPasswordError.set error.detail
+      # TODO: (Austin) better error handling
+      @state.o_newPasswordError.set err.detail
       throw err
     .then ->
       z.router.go '/'

--- a/src/lib/request.coffee
+++ b/src/lib/request.coffee
@@ -36,3 +36,9 @@ module.exports = (url, options) ->
                         url=#{url},
                         options=#{options}"
     return res
+  .catch (err) ->
+    if err?.json
+      err.json().then (error) ->
+        throw error
+    else
+      throw err

--- a/src/models/user.coffee
+++ b/src/models/user.coffee
@@ -40,6 +40,8 @@ class User
     SMALL: SMALL_AVATAR_SIZE
     LARGE: LARGE_AVATAR_SIZE
 
+  DEFAULT_NAME: 'Nameless'
+
   signedUpThisSession: false
 
   getMe: =>
@@ -53,6 +55,7 @@ class User
 
     return me
 
+  #  FIXME: _me must be a promise (streams will hopefully fix)
   setMe: (_me) ->
     me.set _me
 
@@ -76,7 +79,7 @@ class User
           accessToken: me.accessToken
         body: userUpdate
       .then (res) =>
-        @setMe res
+        @setMe Promise.resolve res
 
   getById: (userId) =>
     @getMe().then ({accessToken}) ->

--- a/src/root.coffee
+++ b/src/root.coffee
@@ -41,6 +41,12 @@ KIK_PICKER_MIN_TIMEOUT_MS = 200
 baseStyles.use()
 PortalService.registerMethods()
 
+# Facebook share redirects to ?#_=_, which isn't a route
+# TODO: (Austin) better workaround for this
+# FIXME: somehow send user back to Kik if they shared from Kik?
+if window.location.hash is '#_=_'
+  window.location.hash = ''
+
 ##############
 # KIK PICKER #
 ##############


### PR DESCRIPTION
- whatwg-fetch stopped passing back body info for errors, so we can't gett
  the details. Replaced with our own client-side messages
- fixed a couple of places that looked bad without a name
- don't show kik invite if not kik
- ios tweaks (tap-highlight, ontouchstart for hamburger)
- fix login (Promise.resolve for observable)
- rm the hash facebook appends to url on redirect back to clay